### PR TITLE
feat: add golang dependencies

### DIFF
--- a/data/menu.json
+++ b/data/menu.json
@@ -52,6 +52,19 @@
       "frameworks": {
         "Spring": "spring init --dependencies=web ${projectName}"
       }
+    },
+    "Golang": {
+      "dependency": {
+        "name": "Go",
+        "installationUrl": "https://golang.org/doc/install",
+        "checkCommand": "go version"
+      },
+      "frameworks": {
+        "Default": "go mod init ${projectName}",
+        "Gin": "go get -u github.com/gin-gonic/gin",
+        "Echo": "go get -u github.com/labstack/echo/v4",
+        "Fiber": "go get -u github.com/gofiber/fiber/v2"
+      }
     }
   }
 }


### PR DESCRIPTION
## Change Description ❗

Closes #15 

## Proposed Solution 😎

Added feat add Golang dependencies and frameworks

## Type of Change 👊


- [ ] Bug fix (solution to an error)
- [ ] Functionality improvement
-  New feature
- [ ] Documentation change

## Verification 🕵️‍♀️

The pc where this was tested, it hasn't installed Golang. When the user tries to generate a Golang project using the option default, the following error is shown

![image](https://github.com/fracergu/project-crafter/assets/48018975/230007a0-173c-47f4-ba1a-496013ce6361)


Meaning that user has to installed the dependencies manually

## How It Was Tested 👩‍💻

1) Create project
2) Select Golang
3) The error that dependencies have to be installed manually is shown


## Screenshots (optional) 🙇‍♀️

![image](https://github.com/fracergu/project-crafter/assets/48018975/cbd0c498-6a2e-46ad-9fc7-8017726820dd)

## Checklist 🥰

- [ ] I have read the contribution guidelines.
- [ ] I have updated the documentation if necessary.
- [ ] I have added tests demonstrating that my change works.
-  I have ensured that my code complies with project standards.
- I have tagged the PR correctly for easy discovery and review.

## Additional Notes 🎀

N/A
