### PR TITLE
fix: select default project name

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import { FrameworkOptions } from './models/menu.model'
 import { loadJson } from './utils/json.utils'
 import { verifyTechnologyDependency } from './utils/dependencies.utils'
+import { getProjectName } from './utils/projectName.utils'
 
 // test
 export function activate(context: vscode.ExtensionContext) {
@@ -80,15 +81,8 @@ export function activate(context: vscode.ExtensionContext) {
         return
       }
 
-      // Solicitar al usuario el nombre del proyecto
-      const projectName = await vscode.window.showInputBox({
-        prompt: 'Enter the name of your project',
-        placeHolder: 'my-project',
-      })
-
-      if (!projectName) {
-        return
-      }
+      // Obtener el nombre del proyecto
+      const projectName = await getProjectName()
 
       // Reemplazar el marcador de posición con el nombre del proyecto
       const finalCommand = command.replace('${projectName}', projectName)

--- a/src/utils/projectName.utils.ts
+++ b/src/utils/projectName.utils.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode'
+
+export async function getProjectName(): Promise<string> {
+  const defaultProjectName = 'my-project'
+  // Solicitar al usuario el nombre del proyecto
+  const projectName = await vscode.window.showInputBox({
+    prompt: 'Enter the name of your project, my-project is the default',
+    placeHolder: defaultProjectName,
+  })
+
+  // Si el usuario presiona Tab, usa el nombre predeterminado
+  if (
+    vscode.window.activeTextEditor &&
+    vscode.window.activeTextEditor.selection.isEmpty
+  ) {
+    return defaultProjectName
+  }
+
+  // Devuelve el nombre del proyecto ingresado por el usuario
+  return projectName || defaultProjectName
+}


### PR DESCRIPTION
## Change Description ❗

The user has the chance to use the default project name my-project with all options 

## Proposed Solution 😎

If the user presses enter or tab, the extension will use the default project name my-project

![image](https://github.com/fracergu/project-crafter/assets/48018975/fe0393c5-2999-43ed-8b9f-d09924a50274)


## Type of Change 👊

[Mark with an "x" whichever is applicable]

- [ ] Bug fix (solution to an error)
-  Functionality improvement
- [ ] New feature
- [ ] Documentation change

## Verification 🕵️‍♀️

Tested with react vite template

![image](https://github.com/fracergu/project-crafter/assets/48018975/6443520e-c6f9-4817-a6d7-3ae60fa51bc6)


## How It Was Tested 👩‍💻

### First test with the improvement
1) Create project
2) Node
3) React
4) Vite
5) Press enter when the extension asks for project name

![image](https://github.com/fracergu/project-crafter/assets/48018975/e8438085-b9f8-4cc3-a09d-093a3b3642e6)

### Second test while selecting new project name
1) Create project
2) Node
3) React
4) Vite
5) Enter a new project name

![image](https://github.com/fracergu/project-crafter/assets/48018975/3c193689-8c0a-497a-a8c0-745084008642)

## Checklist 🥰

- [ ] I have read the contribution guidelines.
- [ ] I have updated the documentation if necessary.
- [ ] I have added tests demonstrating that my change works.
-  I have ensured that my code complies with project standards.
-  I have tagged the PR correctly for easy discovery and review.

